### PR TITLE
Make newly created object available to callback closure function

### DIFF
--- a/code/extensions/QuickAddNewExtension.php
+++ b/code/extensions/QuickAddNewExtension.php
@@ -142,7 +142,7 @@ class QuickAddNewExtension extends Extension {
 		}
 
 		$callback = $this->sourceCallback;
-		$items = $callback();
+		$items = $callback($obj);
 		$this->owner->setSource($items);
 
 		// if this field is a multiselect field, we add the new Object ID to the existing


### PR DESCRIPTION
Then within the callback closure function, extra properties can be set (optionally) on the newly created object if necessary.

Example usage:

```
    // Closure for getting tags, including newly created one
    $blogitem = $this;
    $tagsource = function($newtag = null) use($blogitem) { 
        // link created FilterableTag to Parent of this page
        if($newtag){
            $newtag->ItemHolderID = $blogitem->Parent()->ID;
            $newtag->write();
        }
        // return all Tags (including new one)
        return $blogitem->Parent()->Tags()->map()->toArray();
    };
    // Add Categories field
    $tagsList = ListboxField::create(
            "Tags", _t("FilterableArchive.Tags", "Tags"), 
            $tagsource()
        )->setMultiple(true);
    $tagsList->useAddNew('Tag', $tagsource);

    $fields->insertBefore($tagsList, "Content");
```
