### PR TITLE
Set first input of modal form to be focused on dialog open

### DIFF
--- a/javascript/quickaddnew.js
+++ b/javascript/quickaddnew.js
@@ -92,6 +92,8 @@ jQuery.entwine("quickaddnew", function($) {
 
 			dlg.load(this.getURL(), function(){
 				dlg.parent().removeClass("loading");
+				// set focus to first input element
+				dlg.find('form :input:visible:enabled:first').focus();
 			});
 		}
 	});


### PR DESCRIPTION
Should fix the issue of the input in the modal, not receiving focus when opened.