### PR TITLE
Fix quickaddnew sometimes getting entwined twice

### DIFF
--- a/javascript/quickaddnew.js
+++ b/javascript/quickaddnew.js
@@ -18,7 +18,12 @@ jQuery.entwine("quickaddnew", function($) {
 		URL:  null,
 		onmatch: function() {
 			var self = this;
-
+			
+			//Check to see if quickaddnew has been bound to this field before, sometimes jQuery plugins like Select2 
+			//will trigger a binding a second time that we don't want.
+			if($(this).parents().children('.quickaddnew-button').length > 0) {
+				return;
+			}
 			// create add new button
 			var button = $("<button />")
 				.addClass()
@@ -26,12 +31,12 @@ jQuery.entwine("quickaddnew", function($) {
 				.attr('href', '#')
 				.addClass("quickaddnew-button ss-ui-button ss-ui-button-small")
 				.appendTo(self.parents('div:first'));
-
+		
 			// create dialog	
 			var dialog = $("<div />")
 				.addClass("quickaddnew-dialog")
-				.appendTo(self.parents('div:first'));	
-
+				.appendTo(self.parents('div:first'));
+			
 			this.setDialog(dialog);
 
 			// set URL
@@ -87,14 +92,16 @@ jQuery.entwine("quickaddnew", function($) {
 
 		showDialog: function(url) {
 			var dlg = this.getDialog();
+			// Check to see we have a dialog, other jquery plugins like Select2 can get bound to by accident
+			if (dlg !== null) {
+				dlg.empty().dialog("open").parent().addClass("loading");
 
-			dlg.empty().dialog("open").parent().addClass("loading");
-
-			dlg.load(this.getURL(), function(){
-				dlg.parent().removeClass("loading");
-				// set focus to first input element
-				dlg.find('form :input:visible:enabled:first').focus();
-			});
+				dlg.load(this.getURL(), function(){
+					dlg.parent().removeClass("loading");
+					// set focus to first input element
+					dlg.find('form :input:visible:enabled:first').focus();
+				});
+			}
 		}
 	});
 });


### PR DESCRIPTION
Issue stems from jQuery plugins like Select2 re-writing the dom and causing entwine to match quickaddnew to the field a second time. This then causes issues with doubled up buttons and dialogs. The other potential fix is making sure quickaddnew fires last in the page build but this can't be guaranteed.