### PR TITLE
fix(quickaddnew.css): Fix CSS so that the addnew button appears beside the chosen field in a way that works responsively.

### DIFF
--- a/css/quickaddnew.css
+++ b/css/quickaddnew.css
@@ -1,10 +1,17 @@
-.cms .quickaddnew-field{
-	position: relative;
+.cms .quickaddnew-field > .middleColumn {
+	/* stop gaps between inline blocks */
+	font-size: 0;
+}
+.cms .quickaddnew-field .chzn-container {
+	max-width: 437px; /* 512px - 75px */
 }
 .cms .quickaddnew-button{
-	position: absolute;
-	top: 5px;
+	position: relative;
+	top: 4px;
+	z-index: 0;
+	display: inline-block;
 	margin-left: 5px;
+	vertical-align: top;
 }
 
 .quickaddnew-dialog{


### PR DESCRIPTION
Fix the button from just drawing over the input box and other position: absolute; quirks.
![addnew](https://cloud.githubusercontent.com/assets/3859574/19370049/f0dc5ffa-91f4-11e6-9819-bb8c454df2ce.png)


**Tested:**
- Latest Chrome
- Latest Firefox
- Internet Explorer 11